### PR TITLE
issue with AWS tokens assignment

### DIFF
--- a/push.js
+++ b/push.js
@@ -10,8 +10,8 @@ var myApp = new SNS({
   platform: 'android',
   region: 'eu-west-1',
   apiVersion: '2010-03-31',
-  accessKeyId: SNS_ACCESS_KEY,
-  secretAccessKey: SNS_KEY_ID,
+  accessKeyId: SNS_KEY_ID,
+  secretAccessKey: SNS_ACCESS_KEY
   platformApplicationArn: ANDROID_ARN
 });
 


### PR DESCRIPTION
Assignment of accessKeyId and secretAccessKey values are flipped. Fixing it with this PR. 
